### PR TITLE
Directly export to alfredsnippets file and support for vim digraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.alfredsnippets
+build/*
+__pycache__/*

--- a/README.md
+++ b/README.md
@@ -1,46 +1,66 @@
 # import-alfred-snippets
-Import snippets to Alfred 3 from a .csv file
+Import snippets to Alfred 3 from a .csv file or .vim file
 
 The csv needs to be named snippets.csv and must contain exactly three fields: the snippet name, the abbreviation, and the snippet text itself.  For example:
 
-```bash
-
-"any","Pan","PropTypes.any"
-"array","Parr","PropTypes.array"
-"arrayOf","Paro","PropTypes.arrayOf()"
-"bool","Pbo","PropTypes.bool"
-"element","Pel","PropTypes.element"
-"func","Pfn","PropTypes.func"
-"instanceOf","Pio","PropTypes.instanceOf()"
-"node","Pno","PropTypes.node"
-"number","Pnu","PropTypes.number"
-"object","Pobj","PropTypes.object"
-"objectOf","Pobo","PropTypes.objectOf()"
-"oneOf","Poo","PropTypes.oneOf([])"
-"oneOfType","Pot","PropTypes.oneOfType"
-"shape","Psh","PropTypes.shape({})"
-"string","Pst","PropTypes.string"
-
-```
-
 ## Usage
 
-Save the file **importSnippets.py** to a location of your choice - this should probably be a temporary folder because 
-when the script is run, it will generate a file for each snippet.
+Can be used to turn a tab-separated csv file into a alfredsnippets file.
+For example a file `your.csv`:
 
-Save your snippets in a csv file called **snippets.csv** as descibed above, in the same directory where you put the script.
+```bash
+any	Pan	PropTypes.any
+array	Parr	PropTypes.array
+arrayOf	Paro	PropTypes.arrayOf()
+bool	Pbo	PropTypes.bool
+element	Pel	PropTypes.element
+func	Pfn	PropTypes.func
+instanceOf	Pio	PropTypes.instanceOf()
+node	Pno	PropTypes.node
+number	Pnu	PropTypes.number
+object	Pobj	PropTypes.object
+objectOf	Pobo	PropTypes.objectOf()
+oneOf	Poo	PropTypes.oneOf([])
+oneOfType	Pot	PropTypes.oneOfType
+shape	Psh	PropTypes.shape({})
+string	Pst	PropTypes.string
+```
 
-To run the script, open a Terminal window in the same directory where you put the script, then at the prompt, type:
+Can be turned into an alfredsnippets file like this:
 
-**python ./importSnippets.py**
+```bash
+> ./importSnippets.py your.csv Snippets # generates Snippets.alfredsnippets
+```
 
-If all goes well, you should then have individual files in the same directory with names like *any [8760badff15c594b6308564f4460e7].json* , where the text in brackets is a random string generated as the uid (used by Alfred to track usage).
+However it can also be used to generate an alfredsnippets file from a vim file containing declarations with digraphs.
+For example a file `digraphs.vim`:
 
-Move the newly generated files to .../Alfred.alfredpreferences/snippets/*groupname* where groupname is the group where you want the snippets.  Creating a new folder will create a new group in Alfred.  After a few seconds, the new snippets willl appear in Alfred's preferences.  (To view this folder in Finder, you'll need to find your Alfred.alfredpreferences file, right-click and click "Show Package Contents").
+```vim
+""" basic arrows
+digraph -> 8594 " right arrow
+digraph -< 8592 " left arrow
+digraph -- 8596 " leftright
 
-You can then delete or replace **snippets.csv** and start again.
+digraph /> 8603 " right neg arrow
+digraph /< 8602 " left neg arrow
+digraph // 8622 " leftright neg arrow
 
-I have occasionally had errors where the csv library used by the script thinks there are line breaks midway through a field -- the easiest fix I've found is to open snippets.csv in Excel, then save it as csv.
+digraph => 8658 " right double arrow
+digraph =< 8656 " left double arrow
+digraph == 8660 " leftright double arrow
+
+digraph F> 8655 " right double neg arrow
+digraph F< 8653 " left double neg arrow
+digraph FF 8654 " leftright double neg arrow
+```
+
+Can be turned into alfredsnippets like this:
+
+```bash
+> ./fromDigraphToCsv digraphs.vim Snippets # generates Snippets.alfredsnippets
+```
+
+The alfredsnippets can then be imported into Alfred 3.
 
 **DISCLAIMERS**: This is largely untested, and doesn't escape any special characters at the moment.  As far as I can tell, it causes no problems for Alfred, but you use it at your own risk.
 

--- a/fromDigraphToCsv.py
+++ b/fromDigraphToCsv.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+import re
+import os
+import sys
+
+from io import StringIO
+from pathlib import Path
+from typing import Optional, Tuple
+
+from importSnippets import write_csv_to_alfred
+
+digraph_pattern = re.compile(r'^digraph ([^ ]+) (\d+) " (.*)$')
+
+def digraph_line_to_csv(line) -> Optional[Tuple[str, str, str]]:
+    try:
+        gr = digraph_pattern.match(line).groups()
+    except AttributeError:
+        return None
+
+    keyword = gr[0] if len(gr[0]) == 2 else gr[0].replace('\\', '')
+    snippet = chr(int(gr[1]))
+    name = gr[2]
+
+    return snippet, keyword, name
+
+if __name__ == '__main__':
+    currdir = f'{os.path.dirname(os.path.realpath(__file__))}'
+    filename = sys.argv[1] if len(sys.argv) > 1 else Path(currdir, 'digraphs.vim').absolute()
+
+    csv = []
+    try:
+        with open(filename, 'r') as f:
+            for line in f:
+                processed = digraph_line_to_csv(line)
+
+                if processed:
+                    csv.append(processed)
+    except FileNotFoundError as e:
+        print(e)
+
+    write_csv_to_alfred(StringIO('\n'.join(['\t'.join(entry) for entry in csv])))

--- a/importSnippets.py
+++ b/importSnippets.py
@@ -42,6 +42,9 @@ def write_csv_to_alfred(csvfile) -> None:
             print(e)
 
     zipname = f'{sys.argv[2]}.alfredsnippets' if len(sys.argv) > 2 else 'Snippets.alfredsnippets'
+    if os.path.exists(zipname):
+        os.remove(zipname)
+
     with ZipFile(zipname, 'w') as zf:
         for pth in builddir.iterdir():
             zf.write(pth, arcname=pth.name)

--- a/importSnippets.py
+++ b/importSnippets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # importSnippets.py
 #
@@ -6,20 +6,56 @@
 #
 # written for python 2.7.10
 
-
 import csv
 import json
-import os, binascii
+import os
+import sys
+import binascii
 
-sourceFile = 'snippets.csv'
-fieldNames = ['name','keyword','content']
+from shutil import rmtree
+from pathlib import Path
+from zipfile import ZipFile
 
-with open (sourceFile, 'rt') as csvfile:
-	reader = csv.DictReader(csvfile, fieldnames=fieldNames)
-	for row in reader:
-		uid = binascii.b2a_hex(os.urandom(15))
-		output = json.dumps({"alfredsnippet" : {"snippet" : row['content'], "uid": uid, "name" : row['name'], "keyword" : row['keyword']}}, sort_keys=False, indent=4, separators=(',', ': '))
-		outputFile = row['name']+" ["+uid+"].json"
-		f = open(outputFile, 'w')
-		f.write(output)
-		f.close()
+def write_csv_to_alfred(csvfile) -> None:
+    currdir = os.path.dirname(os.path.realpath(__file__))
+    builddir = Path(currdir, 'build')
+    builddir.mkdir(exist_ok=True)
+
+    reader = csv.reader(csvfile, delimiter='\t')
+
+    for row in reader:
+        uid = binascii.b2a_hex(os.urandom(15)).decode()
+        output = json.dumps({
+            'alfredsnippet' : {
+                'snippet' : row[0],
+                'uid': uid,
+                'keyword' : row[1],
+                'name' : row[2],
+            }
+        })
+
+        output_file = builddir / Path(f'{row[2].replace("/", "or")} [{uid}].json')
+        try:
+            with open(output_file, 'w') as f:
+                f.write(output)
+        except OSError as e:
+            print(e)
+
+    zipname = f'{sys.argv[2]}.alfredsnippets' if len(sys.argv) > 2 else 'Snippets.alfredsnippets'
+    with ZipFile(zipname, 'w') as zf:
+        for pth in builddir.iterdir():
+            zf.write(pth, arcname=pth.name)
+
+    try:
+        rmtree(builddir)
+    except FileNotFoundError:
+        pass
+
+if __name__ == '__main__':
+    source_file = sys.argv[1] if len(sys.argv) > 1 else 'snippets.csv'
+
+    try:
+        with open (source_file, 'r') as csvfile:
+            write_csv_to_alfred(csvfile)
+    except FileNotFoundError as e:
+        print(e)


### PR DESCRIPTION
Hi.

I've written an extension to:
1. Export directly to alfredsnippets, rather than a bunch of files.
2. Support vim digraph files, which are basically like snippets but for the vim text editor.
3. Support python3